### PR TITLE
Use intransitiveMap instead of map

### DIFF
--- a/DeepLearning/src/main/scala/com/thoughtworks/deeplearning/DeepLearning.scala
+++ b/DeepLearning/src/main/scala/com/thoughtworks/deeplearning/DeepLearning.scala
@@ -62,7 +62,7 @@ trait DeepLearning[Differentiable] extends SimulacrumIssue82WorkAround[Different
 
   final def train(differentiable: Differentiable)(implicit monoid: MultiplicativeMonoid[Delta]): Future[Data] = {
     val doData = forward(differentiable).flatMap[Data] { tape =>
-      Do.garbageCollected(tape.backward(Do.now(monoid.one))).map { loss =>
+      Do.garbageCollected(tape.backward(Do.now(monoid.one))).intransitiveMap { _: Unit =>
         tape.data
       }
     }


### PR DESCRIPTION
`intransitiveMap` is enough here because the value of `tape.backward` is an `Unit`, which is not a native resource.