### PR TITLE
Files named Aux cause problems on Windows

### DIFF
--- a/src/main/scala/com/package.scala
+++ b/src/main/scala/com/package.scala
@@ -1,0 +1,9 @@
+package com
+
+package object thoughtworks {
+
+  /**
+   * Make unidoc complete full path for `Xxx.Aux`
+   */
+  private class Aux
+}

--- a/src/main/scala/com/thoughtworks/Aux.scala
+++ b/src/main/scala/com/thoughtworks/Aux.scala
@@ -1,6 +1,0 @@
-package com.thoughtworks
-
-/**
-  * Make unidoc complete full path for `Xxx.Aux`
-  */
-private class Aux


### PR DESCRIPTION
I just tried to checkout DeepLearning.scala on Windows, but it seems [Windows has a problem with files being named Aux](https://social.technet.microsoft.com/Forums/Azure/en-US/d1cf7394-a39b-46bf-823d-46f33b2f78d0/unable-to-create-folder-named-quotauxquot-anywhere-in-the-disk?forum=w7itprogeneral)...
I moved the `Aux` class to the corresponding package object and tests are still running successfully.